### PR TITLE
include memory header

### DIFF
--- a/include/essentials.hpp
+++ b/include/essentials.hpp
@@ -16,6 +16,7 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <cassert>
+#include <memory>
 
 #ifdef __GNUG__
 #include <cxxabi.h>  // for name demangling


### PR DESCRIPTION
Since GCC11, in order to use smart pointers, the header <memory> must be explicitly included.

See [Porting to GCC11](https://gcc.gnu.org/gcc-11/porting_to.html), "Header dependency changes" section.