### PR TITLE
Add a missing memory include for std::unique_ptr

### DIFF
--- a/include/essentials.hpp
+++ b/include/essentials.hpp
@@ -16,6 +16,7 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <cassert>
+#include <memory>
 
 #ifdef __GNUG__
 #include <cxxabi.h>  // for name demangling


### PR DESCRIPTION
This fixes the following error when building `pthash`:

```
[ 37%] Building CXX object CMakeFiles/example.dir/src/example.cpp.o
In file included from /home/ivan/projects/pthash/src/../include/encoders/compact_vector.hpp:6,
                 from /home/ivan/projects/pthash/src/../include/encoders/encoders.hpp:3,
                 from /home/ivan/projects/pthash/src/../include/pthash.hpp:3,
                 from /home/ivan/projects/pthash/src/example.cpp:3:
.../essentials/include/essentials.hpp: In function ‘std::string essentials::demangle(const char*)’:
.../essentials/include/essentials.hpp:371:10: error: ‘unique_ptr’ is not a member of ‘std’
  371 |     std::unique_ptr<char, decltype(&std::free)> ptr(
      |          ^~~~~~~~~~
```