### PR TITLE
feat: port to GCC-12

### DIFF
--- a/include/essentials.hpp
+++ b/include/essentials.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <dirent.h>
 #include <cstring>
+#include <memory>
 #include <locale>
 #include <unistd.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Since GCC 12, the `<memory>` header must be explicitly included to use smart pointers.