### PR TITLE
Introduce generic saver/loader and make saving const

### DIFF
--- a/include/essentials.hpp
+++ b/include/essentials.hpp
@@ -283,6 +283,7 @@ struct generic_loader {
         : m_num_bytes_pods(0)
         , m_num_bytes_vecs_of_pods(0)
         , m_is(is) {}
+
     template <typename T>
     void visit(T& val) {
         if constexpr (is_pod<T>::value) {
@@ -343,6 +344,7 @@ private:
 struct generic_saver {
     generic_saver(std::ostream& os)
         : m_os(os) {}
+
     template <typename T>
     void visit(T const& val) {
         if constexpr (is_pod<T>::value) {
@@ -351,6 +353,7 @@ struct generic_saver {
             val.visit(*this);
         }
     }
+
     template <typename T, typename Allocator>
     void visit(std::vector<T, Allocator> const& vec) {
         if constexpr (is_pod<T>::value) {
@@ -361,6 +364,7 @@ struct generic_saver {
             for (auto& v : vec) visit(v);
         }
     }
+
     size_t bytes() {
         return m_os.tellp();
     }

--- a/include/essentials.hpp
+++ b/include/essentials.hpp
@@ -152,7 +152,7 @@ struct json_lines {
             m_properties.back().emplace_back(name, value);
         } else if constexpr (std::is_same<T, bool>::value) {
             m_properties.back().emplace_back(name, value ? "true" : "false");
-        }  else {
+        } else {
             m_properties.back().emplace_back(name, std::to_string(value));
         }
     }

--- a/include/essentials.hpp
+++ b/include/essentials.hpp
@@ -603,8 +603,8 @@ private:
     size_t m_size;
 };
 
-template <typename Visitor>
-static size_t visit(auto&& data_structure, char const* filename) {
+template <typename Visitor, typename T>
+static size_t visit(T&& data_structure, char const* filename) {
     Visitor visitor(filename);
     visitor.visit(data_structure);
     return visitor.bytes();

--- a/include/essentials.hpp
+++ b/include/essentials.hpp
@@ -278,22 +278,11 @@ private:
     std::uniform_int_distribution<IntType> m_distr;
 };
 
-struct loader {
-    loader(char const* filename)
+struct generic_loader {
+    generic_loader(std::istream& is)
         : m_num_bytes_pods(0)
         , m_num_bytes_vecs_of_pods(0)
-        , m_is(filename, std::ios::binary) {
-        if (!m_is.good()) {
-            throw std::runtime_error(
-                "Error in opening binary "
-                "file.");
-        }
-    }
-
-    ~loader() {
-        m_is.close();
-    }
-
+        , m_is(is) {}
     template <typename T>
     void visit(T& val) {
         if constexpr (is_pod<T>::value) {
@@ -333,34 +322,37 @@ struct loader {
 private:
     size_t m_num_bytes_pods;
     size_t m_num_bytes_vecs_of_pods;
-    std::ifstream m_is;
+    std::istream& m_is;
 };
 
-struct saver {
-    saver(char const* filename)
-        : m_os(filename, std::ios::binary) {
-        if (!m_os.good()) {
+struct loader : generic_loader {
+    loader(char const* filename)
+        : m_is(filename, std::ios::binary)
+        , generic_loader(m_is) {
+        if (!m_is.good()) {
             throw std::runtime_error(
                 "Error in opening binary "
                 "file.");
         }
     }
 
-    ~saver() {
-        m_os.close();
-    }
+private:
+    std::ifstream m_is;
+};
 
+struct generic_saver {
+    generic_saver(std::ostream& os)
+        : m_os(os) {}
     template <typename T>
-    void visit(T& val) {
+    void visit(T const& val) {
         if constexpr (is_pod<T>::value) {
             save_pod(m_os, val);
         } else {
             val.visit(*this);
         }
     }
-
     template <typename T, typename Allocator>
-    void visit(std::vector<T, Allocator>& vec) {
+    void visit(std::vector<T, Allocator> const& vec) {
         if constexpr (is_pod<T>::value) {
             save_vec(m_os, vec);
         } else {
@@ -369,9 +361,23 @@ struct saver {
             for (auto& v : vec) visit(v);
         }
     }
-
     size_t bytes() {
         return m_os.tellp();
+    }
+
+private:
+    std::ostream& m_os;
+};
+
+struct saver : generic_saver {
+    saver(char const* filename)
+        : m_os(filename, std::ios::binary)
+        , generic_saver(m_os) {
+        if (!m_os.good()) {
+            throw std::runtime_error(
+                "Error in opening binary "
+                "file.");
+        }
     }
 
 private:
@@ -597,8 +603,8 @@ private:
     size_t m_size;
 };
 
-template <typename T, typename Visitor>
-static size_t visit(T& data_structure, char const* filename) {
+template <typename Visitor>
+static size_t visit(auto&& data_structure, char const* filename) {
     Visitor visitor(filename);
     visitor.visit(data_structure);
     return visitor.bytes();
@@ -606,7 +612,7 @@ static size_t visit(T& data_structure, char const* filename) {
 
 template <typename T>
 static size_t load(T& data_structure, char const* filename) {
-    return visit<T, loader>(data_structure, filename);
+    return visit<loader>(data_structure, filename);
 }
 
 template <typename T>
@@ -615,8 +621,8 @@ static size_t load_with_custom_memory_allocation(T& data_structure, char const* 
 }
 
 template <typename T>
-static size_t save(T& data_structure, char const* filename) {
-    return visit<T, saver>(data_structure, filename);
+static size_t save(T const& data_structure, char const* filename) {
+    return visit<saver>(data_structure, filename);
 }
 
 template <typename T, typename Device>

--- a/include/essentials.hpp
+++ b/include/essentials.hpp
@@ -327,8 +327,8 @@ private:
 
 struct loader : generic_loader {
     loader(char const* filename)
-        : m_is(filename, std::ios::binary)
-        , generic_loader(m_is) {
+        : generic_loader(m_is)
+        , m_is(filename, std::ios::binary) {
         if (!m_is.good()) {
             throw std::runtime_error(
                 "Error in opening binary "
@@ -371,8 +371,8 @@ private:
 
 struct saver : generic_saver {
     saver(char const* filename)
-        : m_os(filename, std::ios::binary)
-        , generic_saver(m_os) {
+        : generic_saver(m_os)
+        , m_os(filename, std::ios::binary) {
         if (!m_os.good()) {
             throw std::runtime_error(
                 "Error in opening binary "

--- a/test/allocator.cpp
+++ b/test/allocator.cpp
@@ -26,15 +26,6 @@ struct basic {
         m_data2.push_back(val2);
     }
 
-    template <typename Visitor>
-    void visit(Visitor& visitor) {
-        visitor.visit(x);
-        visitor.visit(y);
-        visitor.visit(z);
-        visitor.visit(m_data1);
-        visitor.visit(m_data2);
-    }
-
     void print() const {
         std::cout << "x = " << x << "; y = " << y << "; z = " << z << std::endl;
         for (auto val : m_data1) std::cout << val << " ";
@@ -43,12 +34,31 @@ struct basic {
         std::cout << std::endl;
     }
 
+    template <typename Visitor>
+    void visit(Visitor& visitor) {
+        visit(visitor, *this);
+    }
+
+    template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit(visitor, *this);
+    }
+
 private:
     int x;
     int y;
     uint64_t z;
     std::vector<T1> m_data1;
     std::vector<T2> m_data2;
+
+    template <typename Visitor, typename F>
+    static void visit(Visitor& visitor, F&& t) {
+        visitor.visit(t.x);
+        visitor.visit(t.y);
+        visitor.visit(t.z);
+        visitor.visit(t.m_data1);
+        visitor.visit(t.m_data2);
+    }
 };
 
 struct complex {
@@ -71,14 +81,18 @@ struct complex {
         for (auto const& obj : m_data) obj.print();
     }
 
-    template <typename Visitor>
-    void visit(Visitor& visitor) {
-        visitor.visit(m_data);
-    }
-
     // contiguous_memory_allocator& get_allocator() {
     //     return m_allocator;
     // }
+
+    template <typename Visitor>
+    void visit(Visitor& visitor) {
+        visit_impl(visitor, *this);
+    }
+    template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit_impl(visitor, *this);
+    }
 
 private:
     // contiguous_memory_allocator m_allocator;
@@ -86,6 +100,11 @@ private:
                 // allocator<value_type>
                 >
         m_data;
+
+    template <typename Visitor, typename F>
+    static void visit_impl(Visitor& visitor, F&& t) {
+        visitor.visit(t.m_data);
+    }
 };
 
 struct wrapper {
@@ -104,7 +123,12 @@ struct wrapper {
 
     template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(m_data);
+        visit(visitor, *this);
+    }
+
+    template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit(visitor, *this);
     }
 
     /* This function and the allocator are the only two things to add
@@ -118,6 +142,11 @@ private:
     /****************************************************************/
 
     std::vector<complex, allocator<complex>> m_data;
+
+    template <typename Visitor, typename F>
+    static void visit(Visitor& visitor, F&& t) {
+        visitor.visit(t.m_data);
+    }
 };
 
 int main() {

--- a/test/data_structure.cpp
+++ b/test/data_structure.cpp
@@ -24,13 +24,23 @@ struct basic {
 
     template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(x);
-        visitor.visit(m_data);
+        visit(visitor, *this);
+    }
+
+    template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit(visitor, *this);
     }
 
 private:
     int x = 10;
     std::vector<T> m_data;
+
+    template <typename Visitor, typename F>
+    static void visit(Visitor& visitor, F&& t) {
+        visitor.visit(t.x);
+        visitor.visit(t.m_data);
+    }
 };
 
 template <typename T>
@@ -68,15 +78,25 @@ struct collection {
 
     template <typename Visitor>
     void visit(Visitor& visitor) {
-        visitor.visit(x);
-        visitor.visit(m_data);
-        visitor.visit(m_data2);
+        visit(visitor, *this);
+    }
+
+    template <typename Visitor>
+    void visit(Visitor& visitor) const {
+        visit(visitor, *this);
     }
 
 private:
     basic<uint32_t> x;
     std::vector<basic<T>> m_data;
     std::vector<std::vector<uint64_t>> m_data2;
+
+    template <typename Visitor, typename F>
+    static void visit(Visitor& visitor, F&& t) {
+        visitor.visit(t.x);
+        visitor.visit(t.m_data);
+        visitor.visit(t.m_data2);
+    }
 };
 
 int main() {


### PR DESCRIPTION
Hi @jermp! When merging some sshash-related changes, it occured to us that your libraries currently require passing by non-const reference even when saving something, which, from our perspective, idiomatically should be done with const ref. We also often need to save/load stuff using a general ifstream/ofstream. Due to this I took it upon myself to
- implement a more generic version of saver/loader which can work with arbitrary streams. I made sure that this change is non-intrusive, so it will only add some functionality, but shouldn't affect your existing workflows.
- Make saving work with const references.

The later is, unfortunately, a bit more intrusive, but I strongly believe that it would be a better way to handle this. I also think that while propagating it to actual usecases require some work, it is straightforward enough, as I already did this in custom forks of pthash and sshash. If it is of interest to you, I can make separate pull requests to pthash and sshash to merge the new approach to "visit" them, and also help with the migration in your other projects, if necessary.