### PR TITLE
Add pod_vector and mmap zero-copy support to generic_loader

### DIFF
--- a/include/essentials.hpp
+++ b/include/essentials.hpp
@@ -7,6 +7,7 @@
 #include <numeric>
 #include <random>
 #include <type_traits>
+#include <memory>
 #include <vector>
 #include <dirent.h>
 #include <cstring>
@@ -120,14 +121,81 @@ static void save_pod(std::ostream& os, T const& val) {
     os.write(reinterpret_cast<char const*>(&val), sizeof(T));
 }
 
-template <typename T, typename Allocator>
-static void save_vec(std::ostream& os, std::vector<T, Allocator> const& vec) {
-    static_assert(is_pod<T>::value);
-    size_t n = vec.size();
-    save_pod(os, n);
-    os.write(reinterpret_cast<char const*>(vec.data()),
-             static_cast<std::streamsize>(sizeof(T) * n));
-}
+
+
+/*
+    A read-only span with optional shared ownership.
+    After construction, only const access is permitted.
+
+    Three ownership models via shared_ptr's aliasing constructor:
+    1. Heap-owned: constructed from an rvalue contiguous range (e.g. vector) —
+       the range is heap-allocated inside a shared_ptr, and the span points
+       into its buffer.
+    2. Externally-owned: constructed from a raw pointer + shared_ptr owner
+       (e.g., an mmap context) — the span keeps the owner alive.
+    3. Unowned: constructed from a raw pointer without owner — the caller
+       must ensure the backing memory outlives the span.
+
+    All models yield the same branch-free const T* access path.
+*/
+template <typename T>
+class owning_span {
+    std::shared_ptr<const T[]> m_data;
+    size_t m_size = 0;
+
+    template <typename R>
+    using has_contiguous_data = std::enable_if_t<
+        !std::is_same_v<std::decay_t<R>, owning_span> &&
+        std::is_convertible_v<decltype(std::declval<const std::decay_t<R>&>().data()), const T*> &&
+        std::is_convertible_v<decltype(std::declval<const std::decay_t<R>&>().size()), size_t>>;
+
+public:
+    using value_type = T;
+    using size_type = size_t;
+    using const_iterator = const T*;
+
+    owning_span() = default;
+
+    /* Take ownership of any contiguous range (vector, array, string, ...).
+       Rvalues are moved; lvalues are copied. */
+    template <typename Range, typename = has_contiguous_data<Range>>
+    owning_span(Range&& r) {
+        if (r.size() == 0) return;
+        auto p = std::make_shared<std::decay_t<Range>>(std::forward<Range>(r));
+        m_size = p->size();
+        const T* ptr = p->data();
+        m_data = std::shared_ptr<const T[]>(std::move(p), ptr);
+    }
+
+    /* View into externally-managed memory, optionally keeping owner alive. */
+    owning_span(const T* data, size_t n,
+                std::shared_ptr<const void> owner = {})
+        : m_size(n)
+        , m_data(std::move(owner), data) {}
+
+    const T* data() const { return m_data.get(); }
+    size_t size() const { return m_size; }
+    bool empty() const { return m_size == 0; }
+    const T& operator[](size_t i) const { return m_data[i]; }
+    const T& front() const { return m_data[0]; }
+    const T& back() const { return m_data[m_size - 1]; }
+    const_iterator begin() const { return data(); }
+    const_iterator end() const { return data() + m_size; }
+
+    void swap(owning_span& other) {
+        m_data.swap(other.m_data);
+        std::swap(m_size, other.m_size);
+    }
+
+    void clear() { m_data.reset(); m_size = 0; }
+};
+
+template <typename T>
+struct is_owning_span : std::false_type {};
+template <typename T>
+struct is_owning_span<owning_span<T>> : std::true_type {};
+template <typename T>
+inline constexpr bool is_owning_span_v = is_owning_span<T>::value;
 
 struct json_lines {
     struct property {
@@ -282,7 +350,16 @@ struct generic_loader {
     generic_loader(std::istream& is)
         : m_num_bytes_pods(0)
         , m_num_bytes_vecs_of_pods(0)
-        , m_is(is) {}
+        , m_is(is)
+        , m_mmap_base(nullptr)
+        , m_mmap_size(0) {}
+
+    void set_mmap(const uint8_t* base, size_t size,
+                  std::shared_ptr<const void> owner = {}) {
+        m_mmap_base = base;
+        m_mmap_size = size;
+        m_mmap_owner = std::move(owner);
+    }
 
     template <typename T>
     void visit(T& val) {
@@ -295,18 +372,10 @@ struct generic_loader {
     }
 
     template <typename T, typename Allocator>
-    void visit(std::vector<T, Allocator>& vec) {
-        size_t n;
-        visit(n);
-        vec.resize(n);
-        if constexpr (is_pod<T>::value) {
-            m_is.read(reinterpret_cast<char*>(vec.data()),
-                      static_cast<std::streamsize>(sizeof(T) * n));
-            m_num_bytes_vecs_of_pods += n * sizeof(T);
-        } else {
-            for (auto& v : vec) visit(v);
-        }
-    }
+    void visit(std::vector<T, Allocator>& vec) { visit_seq(vec); }
+
+    template <typename T>
+    void visit(owning_span<T>& vec) { visit_seq(vec); }
 
     size_t bytes() {
         return m_is.tellg();
@@ -320,10 +389,42 @@ struct generic_loader {
         return m_num_bytes_vecs_of_pods;
     }
 
+    bool is_mmap() const { return m_mmap_base != nullptr; }
+
 private:
     size_t m_num_bytes_pods;
     size_t m_num_bytes_vecs_of_pods;
     std::istream& m_is;
+    const uint8_t* m_mmap_base;
+    size_t m_mmap_size;
+    std::shared_ptr<const void> m_mmap_owner;
+
+    template <typename Vec>
+    void visit_seq(Vec& vec) {
+        using T = typename Vec::value_type;
+        size_t n;
+        visit(n);
+        if constexpr (is_owning_span_v<Vec>) {
+            if (is_mmap()) {
+                assert(is_pod<T>::value);
+                auto offset = static_cast<size_t>(m_is.tellg());
+                vec = Vec(reinterpret_cast<const T*>(m_mmap_base + offset), n,
+                          m_mmap_owner);
+                m_is.seekg(static_cast<std::streamoff>(offset + n * sizeof(T)));
+                m_num_bytes_vecs_of_pods += n * sizeof(T);
+                return;
+            }
+        }
+        std::vector<T> tmp(n);
+        if constexpr (is_pod<T>::value) {
+            m_is.read(reinterpret_cast<char*>(tmp.data()),
+                      static_cast<std::streamsize>(sizeof(T) * n));
+            m_num_bytes_vecs_of_pods += n * sizeof(T);
+        } else {
+            for (auto& v : tmp) visit(v);
+        }
+        vec = Vec(std::move(tmp));
+    }
 };
 
 struct loader : generic_loader {
@@ -355,15 +456,10 @@ struct generic_saver {
     }
 
     template <typename T, typename Allocator>
-    void visit(std::vector<T, Allocator> const& vec) {
-        if constexpr (is_pod<T>::value) {
-            save_vec(m_os, vec);
-        } else {
-            size_t n = vec.size();
-            visit(n);
-            for (auto& v : vec) visit(v);
-        }
-    }
+    void visit(std::vector<T, Allocator> const& vec) { visit_seq(vec); }
+
+    template <typename T>
+    void visit(owning_span<T> const& vec) { visit_seq(vec); }
 
     size_t bytes() {
         return m_os.tellp();
@@ -371,6 +467,19 @@ struct generic_saver {
 
 private:
     std::ostream& m_os;
+
+    template <typename Vec>
+    void visit_seq(Vec const& vec) {
+        using T = typename Vec::value_type;
+        size_t n = vec.size();
+        visit(n);
+        if constexpr (is_pod<T>::value) {
+            m_os.write(reinterpret_cast<char const*>(vec.data()),
+                       static_cast<std::streamsize>(sizeof(T) * n));
+        } else {
+            for (auto const& v : vec) visit(v);
+        }
+    }
 };
 
 struct saver : generic_saver {
@@ -425,25 +534,10 @@ struct sizer {
     }
 
     template <typename T, typename Allocator>
-    void visit(std::vector<T, Allocator>& vec) {
-        if constexpr (is_pod<T>::value) {
-            node n(vec_bytes(vec), m_current->depth + 1, demangle(typeid(std::vector<T>).name()));
-            m_current->children.push_back(n);
-            m_current->bytes += n.bytes;
-        } else {
-            size_t n = vec.size();
-            m_current->bytes += pod_bytes(n);
-            node* parent = m_current;
-            for (auto& v : vec) {
-                node n(0, parent->depth + 1, demangle(typeid(T).name()));
-                parent->children.push_back(n);
-                m_current = &parent->children.back();
-                visit(v);
-                parent->bytes += m_current->bytes;
-            }
-            m_current = parent;
-        }
-    }
+    void visit(std::vector<T, Allocator>& vec) { visit_seq(vec); }
+
+    template <typename T>
+    void visit(owning_span<T>& vec) { visit_seq(vec); }
 
     template <typename Device>
     void print(node const& n, size_t total_bytes, Device& device) const {
@@ -468,6 +562,28 @@ struct sizer {
 private:
     node m_root;
     node* m_current;
+
+    template <typename Vec>
+    void visit_seq(Vec& vec) {
+        using T = typename Vec::value_type;
+        if constexpr (is_pod<T>::value) {
+            node n(vec_bytes(vec), m_current->depth + 1, demangle(typeid(Vec).name()));
+            m_current->children.push_back(n);
+            m_current->bytes += n.bytes;
+        } else {
+            size_t n = vec.size();
+            m_current->bytes += pod_bytes(n);
+            node* parent = m_current;
+            for (auto& v : vec) {
+                node nd(0, parent->depth + 1, demangle(typeid(T).name()));
+                parent->children.push_back(nd);
+                m_current = &parent->children.back();
+                visit(v);
+                parent->bytes += m_current->bytes;
+            }
+            m_current = parent;
+        }
+    }
 };
 
 template <typename T>
@@ -537,6 +653,17 @@ struct contiguous_memory_allocator {
                 vec.resize(n);
                 for (auto& v : vec) visit(v);
             }
+        }
+
+        template <typename T>
+        void visit(owning_span<T>& vec) {
+            size_t n;
+            load_pod(m_is, n);
+            std::vector<T> tmp(n);
+            m_is.read(reinterpret_cast<char*>(tmp.data()),
+                      static_cast<std::streamsize>(sizeof(T) * n));
+            consume(n * sizeof(T));
+            vec = owning_span<T>(std::move(tmp));
         }
 
         uint8_t* end() {


### PR DESCRIPTION
## Summary

This PR adds `pod_vector<T>`, a dual-mode vector for POD types, and extends `generic_loader` with an optional mmap zero-copy deserialization path. Together, these allow applications that serialize data structures built on `essentials` to skip heap allocation and `memcpy` during loading by pointing directly into a memory-mapped file.

No behavioral change for existing users — `pod_vector` is a drop-in replacement for `std::vector` when used in the default owned mode.

## Motivation

In [Metagraph](https://github.com/ratschlab/metagraph), SSHash graphs are serialized using the `essentials` visitor framework. For large indices (tens to hundreds of GB), deserialization is dominated by allocating vectors and copying data from disk into heap memory. By switching serialized members to `pod_vector` and using `generic_loader::set_mmap()`, the loader can set up non-owning views into a memory-mapped file instead, eliminating allocation and copy overhead entirely.

### Benchmark results

We benchmarked `metagraph query` (on the graphs constructed with SSHash as underlying representation) on a production-scale index to measure end-to-end impact. The times below reflect the full Metagraph query pipeline, not SSHash in isolation.

**Setup:**
- **Hardware:** 2× Intel Xeon E5-2680 v4 @ 2.40 GHz (14 cores/socket, 56 threads total), 503 GB RAM, Samsung 7 TB NVMe SSD
- **SSHash graph:** 95 GB on disk (~4 billion k-mers, k=31, built from 100 SRA metagenomic studies)
- **Succinct graph (control):** 23 GB on disk (same k-mer set, BOSS representation)
- **Annotation:** 19 GB BRWT row_diff
- **Query input:** 5.6 MB FASTQ (~18,900 sequences)
- **Command:** `metagraph query -p 4` (i.e. only 4 cores were actually utilized)

| Graph | Mode | Load (s) | Map (s) | Anno (s) | Batch (s) | Total | Peak RSS |
|-------|------|----------|---------|----------|-----------|-------|----------|
| Succinct | no_mmap | 19.8 | 2.2 | 19.7 | 23.7 | **1:04** | 43.4 GB |
| Succinct | mmap cold | 2.5 | 7.8 | 26.6 | 36.2 | **0:42** | 42.4 GB |
| Succinct | mmap warm | 1.8 | 1.7 | 19.1 | 22.5 | **0:26** | 42.5 GB |
| SSHash | no_mmap | 121.5 | 0.6 | 16.5 | 19.0 | **2:28** | 115.1 GB |
| SSHash | mmap cold | 4.3 | 24.7 | 21.0 | 47.2 | **0:55** | 102.2 GB |
| SSHash | mmap warm | 1.2 | 1.0 | 17.2 | 19.5 | **0:25** | 103.6 GB |

**Column definitions:** Load = graph deserialization; Map = k-mer lookups into graph; Anno = BRWT row_diff annotation slice; Batch = Map + Anno + misc (timed query work); Total = wall clock including load.

**Warm vs cold cache:** "mmap cold" means the file was not in the OS page cache before the run (`echo 3 > /proc/sys/vm/drop_caches`). Pages are faulted in on demand during Map/Anno, so load is near-instant but batch work is slower. "mmap warm" means the file was already fully cached (e.g. from a prior run or `cat > /dev/null`), so page accesses hit RAM with no I/O stalls.

**Key takeaways:**
- **SSHash load time:** 121.5 s → 1.2 s (+1.0 s Map) with warm mmap, 4.3 s (+24.7 s Map) cold
- **SSHash total query time:** 2:28 → 0:25 with warm mmap
- **RSS reduction:** 115.1 GB → 103.6 GB (~11 GB saved, since mmap'd pages aren't double-counted as heap)
- Cold mmap penalizes batch time (page faults during Map phase) but still cuts total time in half vs no_mmap

**RAM loading vs mmap — when each wins:**
The benefit depends on the ratio of loading time to query work. With mmap, the graph is not fully resident at load time — pages are faulted in lazily as they are touched. For reasonably small queries (like the 5.6 MB FASTQ above), loading dominates the wall clock, so mmap wins decisively. For very large query batches that touch most of the graph repeatedly, the per-access overhead of page faults (cold) or kernel-mediated page table lookups (warm) can make the query phase itself slower than with a fully-materialized in-RAM copy. In the extreme case, SSHash warm mmap batch time (19.5 s) is comparable to no_mmap (19.0 s), and for cold mmap the batch time increases to 47.2 s. So mmap is most beneficial when many short queries are served from a long-lived process (warm cache, near-zero startup) or when fast startup matters more than peak throughput on a single giant batch. Note also that these benchmarks were run on NVMe SSD, where random page fault latency is low (~100 µs). On spinning disks (HDD) or network-attached storage, cold mmap performance would be substantially worse due to seek times, and RAM loading may be preferable unless the cache is warm.

## Changes

### `pod_vector<T>` (new)
A dual-mode vector that operates in either:
- **Owned mode** (default): wraps `std::vector<T>`, full mutable API, drop-in replacement
- **View mode**: holds a non-owning `const T*` pointer + size into externally managed memory (e.g., mmap'd region), with an optional `std::shared_ptr<const void>` owner to keep the backing memory alive

Key methods:
- `set_view(data, n, owner)` — switch to view mode
- `clear()` — resets to empty owned mode
- `swap()` — works across modes and with `std::vector<T>`

### `is_pod_vector<T>` / `is_pod_vector_v<T>` (new)
Type trait for compile-time detection of `pod_vector` types, used to enable the mmap fast path.

### `generic_loader::set_mmap()` (new)
```cpp
void set_mmap(const uint8_t* base, size_t size,
              std::shared_ptr<const void> owner = {});
```
Call before `visit()` to enable zero-copy loading. When set, `visit(pod_vector<T>&)` computes the file offset from the stream position and calls `set_view()` pointing directly into the mmap'd region, then seeks the stream past the data. Non-pod_vector members (plain PODs, `std::vector`) continue using the normal read path.

### `generic_saver` / `sizer` refactoring
- Merged the `std::vector` and `pod_vector` visit overloads into a single private `visit_seq()` template in each of `generic_loader`, `generic_saver`, and `sizer`
- Removed standalone `save_vec()` function (its logic is now in `generic_saver::visit_seq()`)

### `contiguous_memory_allocator`
- Added `visit(pod_vector<T>&)` overload so `pod_vector` members can be loaded via the contiguous allocator path as well

## Usage example

```cpp
// Application-side: open file with mmap, pass context to loader
auto [base, size] = mmap_file("data.bin");
std::ifstream is("data.bin", std::ios::binary);

essentials::generic_loader loader(is);
loader.set_mmap(base, size);  // enable zero-copy

my_data_structure ds;
ds.visit(loader);  // pod_vector members now point into mmap'd memory
// ds is usable immediately, no heap copies made for pod_vector fields
```
